### PR TITLE
Add umaps-rails for onboarding

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
 
   triggers {
     githubPush()
-    cron('H H * * *')
+    cron('H/20 * * * *')
   }
 
   stages {

--- a/config.js
+++ b/config.js
@@ -9,6 +9,7 @@ module.exports = {
   platform: 'github',
   repositories: [
     'umts/round-three',
+    'umts/umaps-rails',
   ],
   repositoryCache: 'enabled',
 }


### PR DESCRIPTION
And bump the runs up to every 20 minutes. We only keep 10 runs, and it only takes a few minutes. Folks are going to want things like checking and un-checking boxes to work with less-than-on-day-latency