### PR TITLE
Specify user/group in Jenkins Docker command-line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,1 @@
 FROM renovate/renovate:41.82
-USER root:root

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,6 +30,7 @@ pipeline {
         dockerfile {
           reuseNode true
           args """
+            --user=root:root
             --volume="${env.WORKSPACE}/.renovate-tmp:/tmp/renovate"
             --volume="${env.WORKSPACE}/config.js:/usr/src/app/config.js"
           """


### PR DESCRIPTION
Messed up in #9. Jenkins always tries to use a special user/group with it's command-line flags which overrides whatever it says in the `Dockerfile`. We have to ask for `root:root` at the Jenkins level.