### PR TITLE
Stop requiring dashboard approval for interpreters

### DIFF
--- a/base.json
+++ b/base.json
@@ -12,10 +12,6 @@
       "addLabels": ["javascript"]
     },
     {
-      "matchManagers": ["ruby-version", "nodenv"],
-      "dependencyDashboardApproval": true
-    },
-    {
       "matchDepNames": ["rails"],
       "matchUpdateTypes": ["major", "minor"],
       "dependencyDashboardApproval": true


### PR DESCRIPTION
As we onboard dockerized apps (and others become dockerized) these updates are/will be as easy as just clicking merge in _most_ cases.

As such I think it's appropriate for them to just be created by default. The apps still deployed to bare metal can have per-repo overrides I think?

